### PR TITLE
Return Codes for Contracts

### DIFF
--- a/cauchy-vm/build.rs
+++ b/cauchy-vm/build.rs
@@ -8,4 +8,5 @@ fn main() {
         .arg("--target=wasm32-unknown-unknown")
         .output()
         .expect("failed to build contract");
+    println!("cargo:rerun-if-changed=contractscontract_data/src/main.rs");
 }

--- a/cauchy-vm/src/lib.rs
+++ b/cauchy-vm/src/lib.rs
@@ -19,6 +19,20 @@ pub enum ScriptStatus {
     Killed = 0xDEADBEEF,
 }
 
+pub struct RetVal {
+    cost: u128,
+    script_status: ScriptStatus,
+}
+
+impl RetVal {
+    pub fn status(&self) -> &ScriptStatus {
+        &self.script_status
+    }
+    pub fn cost(&self) -> u128 {
+        self.cost
+    }
+}
+
 #[derive(Debug)]
 pub enum VmErr {
     BadStatus(u32),
@@ -30,10 +44,6 @@ pub fn get_version() -> String {
 }
 
 pub trait CauchyVM {
-    fn initialize(&mut self, script: &Script<'_>) -> Result<ScriptStatus>;
-    fn process_inbox(
-        &mut self,
-        script: &Script<'_>,
-        message: Option<Vec<u8>>,
-    ) -> Result<ScriptStatus>;
+    fn initialize(&mut self, script: &Script<'_>) -> Result<RetVal>;
+    fn process_inbox(&mut self, script: &Script<'_>, message: Option<Vec<u8>>) -> Result<RetVal>;
 }

--- a/cauchy-vm/src/lib.rs
+++ b/cauchy-vm/src/lib.rs
@@ -12,6 +12,7 @@ pub struct Script<'a> {
 
 type Result<T> = std::result::Result<T, VmErr>;
 
+#[derive(Debug, PartialEq)]
 pub enum ScriptStatus {
     Ready = 0x0,
     Completed = 0xFF,

--- a/cauchy-vm/src/lib.rs
+++ b/cauchy-vm/src/lib.rs
@@ -12,8 +12,15 @@ pub struct Script<'a> {
 
 type Result<T> = std::result::Result<T, VmErr>;
 
+pub enum ScriptStatus {
+    Ready = 0x0,
+    Completed = 0xFF,
+    Killed = 0xDEADBEEF,
+}
+
 #[derive(Debug)]
 pub enum VmErr {
+    BadStatus(u32),
     Unknown,
 }
 
@@ -22,6 +29,10 @@ pub fn get_version() -> String {
 }
 
 pub trait CauchyVM {
-    fn initialize(&mut self, script: &Script<'_>) -> Result<()>;
-    fn process_inbox(&mut self, script: &Script<'_>, message: Option<Vec<u8>>) -> Result<()>;
+    fn initialize(&mut self, script: &Script<'_>) -> Result<ScriptStatus>;
+    fn process_inbox(
+        &mut self,
+        script: &Script<'_>,
+        message: Option<Vec<u8>>,
+    ) -> Result<ScriptStatus>;
 }

--- a/cauchy-vm/src/wasm_vm.rs
+++ b/cauchy-vm/src/wasm_vm.rs
@@ -71,11 +71,11 @@ impl WasmVM {
             );
             println!("func '{}' returned {:X?}", func, res);
             match res {
-                Ok(v) if v.len() == 1 => {
+                Ok(v) if v.0.len() == 1 => {
                     save_store("some_txid", &store);
                     Ok(RetVal {
-                        cost: 0,
-                        script_status: ScriptStatus::try_from(v[0])?,
+                        cost: v.1,
+                        script_status: ScriptStatus::try_from(v.0[0])?,
                     })
                 }
                 _ => Err(VmErr::Unknown),

--- a/cauchy-vm/tests/interface_tests.rs
+++ b/cauchy-vm/tests/interface_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod vm_tests {
-    use cauchy_vm::{DefaultVM, Script};
+    use cauchy_vm::{DefaultVM, Script, ScriptStatus};
     use std::include_bytes;
 
     const BASIC_WASM: &[u8] = include_bytes!("contract_data.wasm");
@@ -14,7 +14,9 @@ mod vm_tests {
             script: Vec::from(BASIC_WASM),
             aux_data,
         };
-        DefaultVM::initialize(&script).unwrap();
-        DefaultVM::process_inbox(&script, None).unwrap();
+        let res = DefaultVM::initialize(&script).unwrap();
+        assert_eq!(res, ScriptStatus::Killed);
+        let res = DefaultVM::process_inbox(&script, None).unwrap();
+        assert_eq!(res, ScriptStatus::Completed);
     }
 }

--- a/cauchy-vm/tests/interface_tests.rs
+++ b/cauchy-vm/tests/interface_tests.rs
@@ -7,7 +7,7 @@ mod vm_tests {
 
     #[test]
     fn vm_interface() {
-        let aux_data = Some(vec![0x41, 0x42, 0x43, 0x44, 0x45]);
+        let aux_data = Some(vec![0xEF, 0xBE, 0xAD, 0xDE, 0x45]);
 
         let script = Script {
             func: None,

--- a/cauchy-vm/tests/interface_tests.rs
+++ b/cauchy-vm/tests/interface_tests.rs
@@ -15,8 +15,8 @@ mod vm_tests {
             aux_data,
         };
         let res = DefaultVM::initialize(&script).unwrap();
-        assert_eq!(res, ScriptStatus::Killed);
+        assert_eq!(res.status(), &ScriptStatus::Killed);
         let res = DefaultVM::process_inbox(&script, None).unwrap();
-        assert_eq!(res, ScriptStatus::Completed);
+        assert_eq!(res.status(), &ScriptStatus::Completed);
     }
 }


### PR DESCRIPTION
## Abstract

Contracts should have a means of marking themselves as "dead", "finished", or "ready".  This PR implements that change.

## Misc Changes
Consolidated WASM function call to a wrapper.

## Missing Features

* Integrating the upcoming contract storage as necessary -- i.e. should marking a contract as "dead" affect the way in which it's stored?  Should it still exist in `head` so as to not be allowed to be recreated (maybe as a stub)?
* Cost (to run) is not yet implemented and will always return 0