### PR TITLE
Update rust-vm to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-wasm 0.1.0 (git+https://github.com/TheRealBluesun/rust-wasm)",
+ "rust-wasm 0.1.0 (git+https://github.com/TheRealBluesun/rust-wasm?tag=v0.1.1)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1236,7 +1236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rust-wasm"
 version = "0.1.0"
-source = "git+https://github.com/TheRealBluesun/rust-wasm#e05cd527c80e8e7247bca1887c62d7da7535baf3"
+source = "git+https://github.com/TheRealBluesun/rust-wasm?tag=v0.1.1#d24c5e68da51ae0227107a6693337f61d79ff05d"
 dependencies = [
  "bson 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2099,7 +2099,7 @@ dependencies = [
 "checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
-"checksum rust-wasm 0.1.0 (git+https://github.com/TheRealBluesun/rust-wasm)" = "<none>"
+"checksum rust-wasm 0.1.0 (git+https://github.com/TheRealBluesun/rust-wasm?tag=v0.1.1)" = "<none>"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"

--- a/cauchy-vm/Cargo.toml
+++ b/cauchy-vm/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "*"
-rust-wasm = {git="https://github.com/TheRealBluesun/rust-wasm", tag="v0.1.0"}
+rust-wasm = {git="https://github.com/TheRealBluesun/rust-wasm", tag="v0.1.1"}
 digest = "*"
 rayon = "*"
 


### PR DESCRIPTION
## Abstract

This PR updates the rust-vm to expose the "cost to run".  Limited release notes can be found [here](https://github.com/TheRealBluesun/rust-wasm/releases/tag/v0.1.1)